### PR TITLE
update Go to 1.26.4 (and only run govulncheck once a week)

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,7 +1,7 @@
 name: scheduled govulncheck scan
 on:
   schedule:
-    - cron: '11 6 * * 1-5'
+    - cron: '11 6 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/cdk/go.mod
+++ b/cdk/go.mod
@@ -1,6 +1,6 @@
 module cdk
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.225.0

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.org/sil-org/cloudflare-scanner
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/aws/aws-lambda-go v1.52.0


### PR DESCRIPTION
[ITSESUP-77](https://support.gtis.sil.org/tickets/ITSESUP-77) cloudflare-scanner govulncheck alert

---

### Security

- Update Go to 1.26.4 to address vulnerabilities GO-2026-5037 and GO-2026-5039.