### PR TITLE
Update notification email address in govulncheck.yaml

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -19,4 +19,4 @@ jobs:
       aws-region: ${{ vars.AWS_REGION }}
       aws-role: arn:aws:iam::369020531563:role/cloudflare-scanner-cd
       from-email: gtis_itse_alerts@groups.sil.org
-      to-email: gtis_itse_support@sil.org
+      to-email: gtis_itse_support+notifications@sil.org


### PR DESCRIPTION
[ITSE-2921](https://support.gtis.sil.org/issue/ITSE-2921) Update govuln email alerts to go to gtis_itse_support+notifications@sil.org